### PR TITLE
amend results file name to not include .tms

### DIFF
--- a/src/java/xmod/experimenter/ExperimentResulter.java
+++ b/src/java/xmod/experimenter/ExperimentResulter.java
@@ -150,8 +150,8 @@ public class ExperimentResulter {
         byte[] byteString = resultsString.getBytes();
 
         // Set results filename
-        Path tmsBareFileName = Paths.get(this.tmsFileName).getFileName();
-        String resultsFilename = tmsBareFileName.toString() + "_"
+        String tmsBareFileName = Utils.getBareName(this.tmsFileName);
+        String resultsFilename = tmsBareFileName + "_"
                             + dateString + "_" + timeString + ".txt";
         Path resultsFile = Paths.get(this.resultsDir.toString(),
                                     resultsFilename);


### PR DESCRIPTION
# Description
Results file name incorrectly included the .tms extension. This has now been fixed.

# Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

# Relevant Issues
closes #41 

# Testing
Manual

# Checklist
- [X] I have run the checkstyle linter with sun_checks.xml and corrected any issues
- [X] I have performed a self-review of my code
- [X] I have commented my code
- [X] New and existing unit tests pass locally with my changes 
