### PR TITLE
Print name of results file for aborted experiment to screen

### DIFF
--- a/src/java/xmod/experimenter/ExperimentResulter.java
+++ b/src/java/xmod/experimenter/ExperimentResulter.java
@@ -57,6 +57,8 @@ public class ExperimentResulter {
 
     /** Directory to save results to. */
     private Path resultsDir;
+    /** Name of results file. */
+    private Path resultsFile;
     /** Number of boxes in the system - fixed at 16. */
     private static final int NUM_BOXES = 16;
 
@@ -139,6 +141,13 @@ public class ExperimentResulter {
     }
 
     /**
+     * Return location of results file.
+     * @return name of results file as string
+     */
+    public String getResultsFile() {
+        return resultsFile.toString();
+    }
+    /**
      * Save the results of all the trials to file.
      */
     public void printResults() {
@@ -153,7 +162,7 @@ public class ExperimentResulter {
         String tmsBareFileName = Utils.getBareName(this.tmsFileName);
         String resultsFilename = tmsBareFileName + "_"
                             + dateString + "_" + timeString + ".txt";
-        Path resultsFile = Paths.get(this.resultsDir.toString(),
+        resultsFile = Paths.get(this.resultsDir.toString(),
                                     resultsFilename);
         // Write to file
         try {

--- a/src/java/xmod/experimenter/ExperimentRunner.java
+++ b/src/java/xmod/experimenter/ExperimentRunner.java
@@ -295,7 +295,8 @@ public class ExperimentRunner implements PropertyChangeListener {
             // If experiment aborted by user
             updateStatus(Responses.EXPERIMENT_ABORTED,
                         "Experiment aborted by user<br/>"
-                        + "Results to date printed to file in results/",
+                        + "Results to date printed to file in "
+                        + this.expResulter.getResultsFile(),
                         "", "", ReportLabel.STATUS);
         }
         this.expWindow.hide();


### PR DESCRIPTION
# Description
When the user aborts the experiment, a results file is still generated of the results to date. Previously, if aborted it just alerted the user that the file was in results/. Now it gives the whole path and file name.

# Type of Change
- [X] New feature (non-breaking change which adds functionality)

# Testing
Manual

# Checklist
- [X] I have run the checkstyle linter with sun_checks.xml and corrected any issues
- [X] I have performed a self-review of my code
- [X] I have commented my code